### PR TITLE
make sbcl build option consistent with FreeBSD's sbcl port

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         suffix: ['', '-15.0', '-14.3', '-13.5', '-14.2', '-13.4', '-14.1', '-13.3', '-14.0', '-13.2']
         target: ['x86-64', 'x86', 'arm64']
+        sbcloptions: '--with-sb-thread --with-sb-core-compression --without-gencgc --with-mark-region-gc --with-sb-linkable-runtime --with-sb-qshow --with-sb-safepoint --with-sb-thruption --with-sb-wtimer --with-sb-simd --with-sb-thread --with-sb-unicode --with-sb-xref-for-internal'
         include:
           # default lisp used is sbcl-bin/2.4.8
           - lisp: 'sbcl-bin/2.4.8'


### PR DESCRIPTION
Add the following option to FreeBSD's sbcl build option

`--with-sb-thread --with-sb-core-compression --without-gencgc --with-mark-region-gc --with-sb-linkable-runtime --with-sb-qshow --with-sb-safepoint --with-sb-thruption --with-sb-wtimer --with-sb-simd --with-sb-thread --with-sb-unicode --with-sb-xref-for-internal`

to make it consistent with FreeBSD's sbcl port